### PR TITLE
Add sage mode training interaction

### DIFF
--- a/src/main/java/net/narutomod/entity/EntitySlug.java
+++ b/src/main/java/net/narutomod/entity/EntitySlug.java
@@ -15,9 +15,11 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Item;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.entity.IRangedAttackMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.EntityLivingBase;
@@ -42,6 +44,7 @@ import net.minecraft.pathfinding.PathNavigate;
 
 import net.narutomod.procedure.ProcedureUtils;
 import net.narutomod.item.ItemJutsu;
+import net.narutomod.item.ItemSenjutsu;
 import net.narutomod.Particles;
 import net.narutomod.ElementsNarutomodMod;
 
@@ -235,18 +238,36 @@ public class EntitySlug extends ElementsNarutomodMod.ModElement {
 		public void setSwingingArms(boolean swingingArms) {
 		}
 
-		@Override
-		public void onUpdate() {
-			super.onUpdate();
-			this.fallDistance = 0.0f;
-			if (!this.world.isRemote) {
+                @Override
+                public void onUpdate() {
+                        super.onUpdate();
+                        this.fallDistance = 0.0f;
+                        if (!this.world.isRemote) {
 				EntityLivingBase summoner = this.getSummoner();
 				if (summoner != null && !summoner.isRiding() && this.getAge() == 1 && this.getScale() >= 4.0f) {
 					summoner.startRiding(this);
 				}
 				this.checkClimbing();
-			}
-		}
+                        }
+                }
+
+                @Override
+                public boolean processInteract(EntityPlayer player, EnumHand hand) {
+                        super.processInteract(player, hand);
+                        ItemStack stack = player.getHeldItem(hand);
+                        if (stack.getItem() == ItemSenjutsu.block) {
+                                if (!this.world.isRemote) {
+                                        ItemSenjutsu.RangedItem item = (ItemSenjutsu.RangedItem)stack.getItem();
+                                        item.setSageType(stack, ItemSenjutsu.Type.SLUG);
+                                        item.enableJutsu(stack, ItemSenjutsu.SAGEMODE, true);
+                                        player.sendStatusMessage(new TextComponentTranslation(
+                                         "chattext.sagemode.learn",
+                                         ItemSenjutsu.Type.SLUG.getLocalizedName()), true);
+                                }
+                                return true;
+                        }
+                        return false;
+                }
 
 		private void checkClimbing() {
 			EnumFacing side = EnumFacing.DOWN;

--- a/src/main/java/net/narutomod/entity/EntitySnake8Heads.java
+++ b/src/main/java/net/narutomod/entity/EntitySnake8Heads.java
@@ -17,6 +17,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraft.world.World;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.RayTraceResult;
@@ -36,6 +37,7 @@ import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.text.TextComponentTranslation;
 
 import net.narutomod.potion.PotionFeatherFalling;
 import net.narutomod.procedure.ProcedureUtils;
@@ -128,11 +130,11 @@ public class EntitySnake8Heads extends ElementsNarutomodMod.ModElement {
 			}
 		}
 
-		@Override
-		public void onUpdate() {
-			super.onUpdate();
-			if (this.ticksExisted == 1) {
-				this.playSound(SoundEvent.REGISTRY.getObject(new ResourceLocation("narutomod:woodspawn")), 5f, 1f);
+                @Override
+                public void onUpdate() {
+                        super.onUpdate();
+                        if (this.ticksExisted == 1) {
+                                this.playSound(SoundEvent.REGISTRY.getObject(new ResourceLocation("narutomod:woodspawn")), 5f, 1f);
 			} else if (this.ticksExisted == this.upTime) {
 				this.playSound(SoundEvent.REGISTRY.getObject(new ResourceLocation("narutomod:snake_hiss")), 5f, 0.7f);
 			} else if (this.ticksExisted <= this.upTime + this.waitTime && this.ticksExisted % 5 == 1) {
@@ -149,9 +151,27 @@ public class EntitySnake8Heads extends ElementsNarutomodMod.ModElement {
 				if (summoner != null && (!Chakra.pathway(summoner).consume(this.chakraBurn) || !this.isSageModeActive(summoner))) {
 					this.setDead();
 				}
-			}
-			this.setTicksAlive(this.getTicksAlive() + 1);
-		}
+                        }
+                        this.setTicksAlive(this.getTicksAlive() + 1);
+                }
+
+                @Override
+                public boolean processInteract(EntityPlayer player, EnumHand hand) {
+                        super.processInteract(player, hand);
+                        ItemStack stack = player.getHeldItem(hand);
+                        if (stack.getItem() == ItemSenjutsu.block) {
+                                if (!this.world.isRemote) {
+                                        ItemSenjutsu.RangedItem item = (ItemSenjutsu.RangedItem)stack.getItem();
+                                        item.setSageType(stack, ItemSenjutsu.Type.SNAKE);
+                                        item.enableJutsu(stack, ItemSenjutsu.SAGEMODE, true);
+                                        player.sendStatusMessage(new TextComponentTranslation(
+                                         "chattext.sagemode.learn",
+                                         ItemSenjutsu.Type.SNAKE.getLocalizedName()), true);
+                                }
+                                return true;
+                        }
+                        return false;
+                }
 
 		private boolean isSageModeActive(EntityLivingBase summoner) {
 			if (summoner instanceof EntityPlayer) {

--- a/src/main/java/net/narutomod/entity/EntityToadFukasaku.java
+++ b/src/main/java/net/narutomod/entity/EntityToadFukasaku.java
@@ -12,6 +12,10 @@ import net.minecraftforge.fml.client.registry.RenderingRegistry;
 
 import net.minecraft.world.World;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.EnumHand;
+import net.minecraft.item.ItemStack;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.Entity;
 import net.minecraft.client.model.ModelRenderer;
@@ -19,6 +23,8 @@ import net.minecraft.client.model.ModelBox;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.GlStateManager;
+
+import net.narutomod.item.ItemSenjutsu;
 
 @ElementsNarutomodMod.ModElement.Tag
 public class EntityToadFukasaku extends ElementsNarutomodMod.ModElement {
@@ -70,19 +76,37 @@ public class EntityToadFukasaku extends ElementsNarutomodMod.ModElement {
 			}
 		}*/
 
-		@Override
-		public void onUpdate() {
-			super.onUpdate();
-			int age = this.getAge();
-			EntityLivingBase summoner = this.getSummoner();
+                @Override
+                public void onUpdate() {
+                        super.onUpdate();
+                        int age = this.getAge();
+                        EntityLivingBase summoner = this.getSummoner();
 			if (summoner != null && age == 1) {
 				this.startRiding(summoner);
 			}
-			if (age == 3) {
-				ProcedureUtils.poofWithSmoke(this);
-			}
-		}
-	}
+                        if (age == 3) {
+                                ProcedureUtils.poofWithSmoke(this);
+                        }
+                }
+
+                @Override
+                public boolean processInteract(EntityPlayer player, EnumHand hand) {
+                        super.processInteract(player, hand);
+                        ItemStack stack = player.getHeldItem(hand);
+                        if (stack.getItem() == ItemSenjutsu.block) {
+                                if (!this.world.isRemote) {
+                                        ItemSenjutsu.RangedItem item = (ItemSenjutsu.RangedItem)stack.getItem();
+                                        item.setSageType(stack, ItemSenjutsu.Type.TOAD);
+                                        item.enableJutsu(stack, ItemSenjutsu.SAGEMODE, true);
+                                        player.sendStatusMessage(new TextComponentTranslation(
+                                         "chattext.sagemode.learn",
+                                         ItemSenjutsu.Type.TOAD.getLocalizedName()), true);
+                                }
+                                return true;
+                        }
+                        return false;
+                }
+        }
 
 	@Override
 	public void preInit(FMLPreInitializationEvent event) {

--- a/src/main/resources/assets/narutomod/lang/en_us.lang
+++ b/src/main/resources/assets/narutomod/lang/en_us.lang
@@ -505,6 +505,7 @@ entity.ninja_kumo.name=Ninja Kumo
 entity.adamantine_prison.name=Adamantine Prison
 item.fuma_shuriken.name=Fuma Shuriken
 chattext.senjutsu.denied=%s says no!
+chattext.sagemode.learn=You have acquired %s Sage Mode!
 advancements.yooton_acquired.descr=Lava Release ("Corrosion Style" or "Lava Style") is a nature transformation kekkei genkai, a combination of fire and earth.
 tooltip.general.powerupkey=Press [Switch Jutsu] to cycle through abilities
 subtitles.toadchant=


### PR DESCRIPTION
## Summary
- let players talk to Fukasaku, Katsuyu or the Eight‑Headed Snake to set their sage type
- add translation for learning sage mode
- notify players when they gain sage mode

## Testing
- `./gradlew tasks --all` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849c1bea37c83309a3f1e20b6cf1f1f